### PR TITLE
Include LALSuite version in package version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # lal
+
 Python binary distribution of a minimum set of lalsuite tools
+
+## Version number
+
+The version number has two parts: the LALSuite version number and possibly a
+minlal revision number. The minlal revision number is treated as a
+[post-release number in the manner described by PEP 440][1].
+
+For example, suppose that there is a LALSuite release 6.48. Then each time the
+minlal package is updated, the resulting Python package will have the following
+version numbers:
+
+1.  `6.48`
+2.  `6.48.post1`
+3.  `6.48.post2`
+4.  `6.48.post3`
+5.  etc.
+
+[1]: https://www.python.org/dev/peps/pep-0440/#post-release-spelling

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,4 +1,4 @@
-LALSUITE_VERSION=6.48
+LALSUITE_VERSION=$(python setup.py --version | sed 's/\.post.*$//')
 
 mkdir local
 export PATH=$PATH:/opt/python/cp27-cp27mu/bin/:$PWD/local/bin

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -1,5 +1,5 @@
 # I have no idea how to build things on mac, this is going to be rough....
-LALSUITE_VERSION=6.48
+LALSUITE_VERSION=$(python setup.py --version | sed 's/\.post.*$//')
 mkdir local
 
 export PATH=$PATH:$PWD/local/bin:$HOME/Library/Python/2.7/bin

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ class bdist_wheel(_bdist_wheel):
         self.root_is_pure = False
 
 setup(name='lal',
-      version='0.0.10',
+      version='6.48.post1',
       description='LIGO Algorithm Library for Python',
       author='Alex Nitz',
       author_email='alex.nitz@aei.mpg.de',


### PR DESCRIPTION
Adopt a two-part version number scheme consisting of the LALSuite version number and possibly a
minlal revision number. The minlal revision number is treated as a [post-release number in the manner described by PEP 440][1].

For example, suppose that there is a LALSuite release 6.48. Then each time the minlal package is updated, the resulting Python package will have the following version numbers:

1.  `6.48`
2.  `6.48.post1`
3.  `6.48.post2`
4.  `6.48.post3`
5.  etc.

[1]: https://www.python.org/dev/peps/pep-0440/#post-release-spelling
